### PR TITLE
Motion profile

### DIFF
--- a/stride_ws/params/params.yaml
+++ b/stride_ws/params/params.yaml
@@ -33,4 +33,4 @@ v_max: 1.5 # max linear velocity in m/s (5.6 almost max speed, 3 is good)
 w_max_spin_in_place: 2 # max angular velocity when spinning in place in rad/s (5 is fast, 2 is good)
 
 # Return to Start
-reverse_speed_goal: -2
+reverse_speed_goal: -1.5 #m/s

--- a/stride_ws/params/params.yaml
+++ b/stride_ws/params/params.yaml
@@ -31,3 +31,6 @@ P_corr: 18
 ### joystick
 v_max: 3 # max linear velocity in m/s (5.6 almost max speed, 3 is good)
 w_max_spin_in_place: 2 # max angular velocity when spinning in place in rad/s (5 is fast, 2 is good)
+
+# Return to Start
+reverse_speed_goal: -2

--- a/stride_ws/params/params.yaml
+++ b/stride_ws/params/params.yaml
@@ -29,7 +29,7 @@ k_r: 0.954
 P_corr: 18
 
 ### joystick
-v_max: 3 # max linear velocity in m/s (5.6 almost max speed, 3 is good)
+v_max: 1.5 # max linear velocity in m/s (5.6 almost max speed, 3 is good)
 w_max_spin_in_place: 2 # max angular velocity when spinning in place in rad/s (5 is fast, 2 is good)
 
 # Return to Start

--- a/stride_ws/src/path_follower/scripts/follower.py
+++ b/stride_ws/src/path_follower/scripts/follower.py
@@ -165,15 +165,15 @@ class PathFollower:
         self.path_intervals_publisher.publish(msg)
 
     def update_current_path_index(self):
-        if self.current_path_index == self.max_index:
+        if self.last_path_index == self.max_index:
             return
 
         # Find slope of line (m) connecting current index and the next index
-        x_cur = self.path_easts[self.current_path_index]
-        y_cur = self.path_norths[self.current_path_index]
+        x_cur = self.path_easts[self.last_path_index]
+        y_cur = self.path_norths[self.last_path_index]
 
-        x_next = self.path_easts[min(self.current_path_index + 1, self.max_index)]
-        y_next = self.path_norths[min(self.current_path_index + 1, self.max_index)]
+        x_next = self.path_easts[min(self.last_path_index + 1, self.max_index)]
+        y_next = self.path_norths[min(self.last_path_index + 1, self.max_index)]
         m = (y_next - y_cur) / (x_next - x_cur)
 
         # Slope of the perpendicular line to the original line
@@ -190,10 +190,10 @@ class PathFollower:
 
         # If the two above points are on different sides of the line
         if k_cur * k_robot < 0:
-            self.current_path_index += 1
+            self.last_path_index += 1
         
-        self.current_path_index_publisher.publish(self.current_path_index)
-        self.last_path_index = self.current_path_index
+        self.current_path_index_publisher.publish(self.last_path_index)
+        self.current_path_index = self.last_path_index
 
     def update_turning_radius(self):
         # Notes: Since angular velocity is positive for anti-clockwise, turning raidus is positive when it's on the robot's left side
@@ -348,7 +348,7 @@ if __name__ ==  '__main__':
             pf.update_path_index_return_to_start()
             pf.update_turning_radius_return_to_start()
             pf.turning_radius_publisher.publish(pf.turning_radius)
-        else:
+        elif pf.overseer_state not in (E_STOPPED, AUTO, RETURN_TO_START):
             pf.current_path_index = 0
             pf.current_path_index_publisher.publish(0)
             pf.turning_radius = 999

--- a/stride_ws/src/robot_commander/launch/robot_commander.launch
+++ b/stride_ws/src/robot_commander/launch/robot_commander.launch
@@ -1,3 +1,5 @@
 <launch>
-  <node pkg="robot_commander" type="robot_commander.py" name="robot_commander" output="screen" cwd="node" respawn="true" />
+  <node pkg="robot_commander" type="robot_commander.py" name="robot_commander" output="screen" cwd="node" respawn="true">
+    <rosparam file="$(find robot_commander)/../../params/params.yaml" command="load"/>
+  </node>
 </launch>

--- a/stride_ws/src/robot_commander/scripts/return_to_start.py
+++ b/stride_ws/src/robot_commander/scripts/return_to_start.py
@@ -1,4 +1,4 @@
 rc = RobotCommander()
 
 print("INFO: Return to start")
-rc.move_until_beginning_of_path(-1.5, 0.1*9.81)
+rc.move_until_beginning_of_path(-2, 0.5)

--- a/stride_ws/src/robot_commander/scripts/return_to_start.py
+++ b/stride_ws/src/robot_commander/scripts/return_to_start.py
@@ -1,4 +1,5 @@
 rc = RobotCommander()
 
 print("INFO: Return to start")
-rc.move_until_beginning_of_path(-2, 0.5)
+rc.move_until_beginning_of_path(rc.reverse_speed_goal, 0.5)
+

--- a/stride_ws/src/robot_commander/scripts/robot_commander.py
+++ b/stride_ws/src/robot_commander/scripts/robot_commander.py
@@ -99,12 +99,8 @@ class RobotCommander:
             while self.current_path_index > 0 and let_script_runs:
                 if self.current_path_index >=  acceleration_distance:
                     velocity_input = math.copysign((min(abs(acceleration * (time.time()-initial_time_in_s)), abs(speed_goal))), speed_goal)
-                    self._send_velocity_command_using_radius(velocity_input)
-                    r.sleep()
                 elif self.current_path_index >=  const_vel_distance:
                     velocity_input =  current_velocity
-                    self._send_velocity_command_using_radius(velocity_input)
-                    r.sleep()
                 else:
                     if is_starting_decel: 
                         d = sum(self.path_intervals[0 : self.current_path_index])
@@ -112,23 +108,20 @@ class RobotCommander:
                         is_starting_decel = False
 
                     velocity_input = math.copysign(max(abs(current_velocity + a*period) , abs(minimum_decel_vel)), speed_goal) #current velocity is -ve
-                    self._send_velocity_command_using_radius(velocity_input)
-                    r.sleep() 
+                self._send_velocity_command_using_radius(velocity_input)
+                r.sleep() 
                 current_velocity = velocity_input
                 
         else: #forward motion
-            acceleration_distance = total_distance_in_index/3
-            const_vel_distance = total_distance_in_index*2/3
+            distance_to_be_covered = total_distance_in_index-self.current_path_index 
+            acceleration_distance = self.current_path_index + distance_to_be_covered/3
+            const_vel_distance = self.current_path_index + distance_to_be_covered*2/3
 
             while self.current_path_index < total_distance_in_index and let_script_runs:
                 if self.current_path_index <=  acceleration_distance:
                     velocity_input = min(acceleration * (time.time()-initial_time_in_s), speed_goal)
-                    self._send_velocity_command_using_radius(velocity_input)
-                    r.sleep()
                 elif self.current_path_index <=  const_vel_distance:
                     velocity_input = current_velocity
-                    self._send_velocity_command_using_radius(velocity_input)
-                    r.sleep()
                 else:
                     if is_starting_decel: 
                         d = sum(self.path_intervals[self.current_path_index : total_distance_in_index])
@@ -136,8 +129,8 @@ class RobotCommander:
                         is_starting_decel = False
 
                     velocity_input = max(current_velocity - a*period, minimum_decel_vel) 
-                    self._send_velocity_command_using_radius(velocity_input)
-                    r.sleep() 
+                self._send_velocity_command_using_radius(velocity_input)
+                r.sleep() 
                 current_velocity = velocity_input
 
     def move_until_end_of_path(self, speed_goal, speed_rate):

--- a/stride_ws/src/robot_commander/scripts/robot_commander.py
+++ b/stride_ws/src/robot_commander/scripts/robot_commander.py
@@ -34,6 +34,7 @@ dash_line = "----------------------"
 
 class RobotCommander:
     def __init__(self):
+        self.reverse_speed_goal = rospy.get_param('~reverse_speed_goal')
         self.current_path_index = 0
         self.max_path_index = -1
         self.path_intervals = []
@@ -106,7 +107,7 @@ class RobotCommander:
                     r.sleep()
                 else:
                     if is_starting_decel: 
-                        d = sum(self.path_intervals[ 0 : self.current_path_index ])
+                        d = sum(self.path_intervals[0 : self.current_path_index])
                         a = current_velocity**2 / (2*d) #vf^2 = vi^2 + 2*a*d
                         is_starting_decel = False
 


### PR DESCRIPTION
![forward_motion_previous_implementation](https://user-images.githubusercontent.com/42899705/211912280-be8ff14e-07cc-494a-bb19-3b095fe0564b.png)

Previous implementation of velocity profile does not provide a deceleration phase for both forward and reverse motions as shown in the picture above (forward motion). This branch deals with the addition of a rate limiter that creates a trapezoidal motion profile to limit jerk and add deceleration instead of stopping at max speed upon reaching the destination. (Picture below shows the trapezoidal motion profile for forward motion) 

![forward_motion_current_implementation](https://user-images.githubusercontent.com/42899705/211912340-e082cd5b-924c-4f61-ab4f-02052bfc63b6.png)

**Additional code changes include:**
Param file variable for reverse speed goal
Reduced manual control max velocity to 1.5m/s from 3m/s
Updated path follower to account for ESTOP state 